### PR TITLE
修复下拉框bug

### DIFF
--- a/src/components/SystemSelect.vue
+++ b/src/components/SystemSelect.vue
@@ -114,7 +114,7 @@ const handleDownload = async index => {
 };
 
 const kernelOptions = computed(() => {
-  const allImageSuites = props.itemList.flatMap(item => item.imagesuites || []);
+  const allImageSuites = props.item.imagesuites
   const allKernels = allImageSuites.map(suite => ({
     value: `${suite.kernel.type}-${suite.kernel.branch}`,
     label: `${suite.kernel.type}-${suite.kernel.branch}`,
@@ -132,8 +132,9 @@ const kernelOptions = computed(() => {
 });
 
 const packageOptions = computed(() => {
-  if (!props.itemList) return [];
-  const allImageSuites = props.itemList.flatMap(item => item.imagesuites || []);
+  if (!props.item) return [];
+  const allImageSuites = props.item.imagesuites
+  console.log(allImageSuites,"我啊all")
   return Array.from(
     new Set(
       allImageSuites.map(suite =>
@@ -261,7 +262,7 @@ const getFileName = url => {
                 <div class="selected-value">
                   {{
                     kernelOptions.find(opt => opt.value === selectedKernel)
-                      ?.label
+                      ?.label || kernelOptions[0].label
                   }}
                   <span
                     v-if="
@@ -315,7 +316,7 @@ const getFileName = url => {
                 <div class="selected-value">
                   {{
                     packageOptions.find(opt => opt.value === selectedPackage)
-                      ?.label
+                      ?.label || packageOptions[0].label
                   }}
                 </div>
                 <img


### PR DESCRIPTION
### 修改allImageSuites以及设置默认选项值
对应issue:[2](https://github.com/openeuler-riscv/imagepub-web/issues/2)
内核版本和软件包场景下拉框都已修复
- ubantu谷歌浏览器测试：
![image](https://github.com/user-attachments/assets/671a3d03-fdd9-4227-b096-0018347ed3f3)
![image](https://github.com/user-attachments/assets/4b0490d7-c34d-4957-995e-c7cb434b00b2)
![image](https://github.com/user-attachments/assets/d7f70cfa-8ec7-4e63-83a6-b5f24cbe8a5c)

- ubantu firefox浏览器测试：
![image](https://github.com/user-attachments/assets/488e07f1-4118-449c-a1e7-2695aeb04136)
![image](https://github.com/user-attachments/assets/ceffe2dc-b422-433a-a174-96b7e2a9b393)
![image](https://github.com/user-attachments/assets/337be4d4-2da6-45dc-9a9f-aeb70f038a55)


